### PR TITLE
feat: Configurable RBF distance expansion for bond features

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -2,7 +2,6 @@ name: qtaim_embed
 channels:
   - conda-forge
   - defaults
-  - dglteam/label/th24_cu124
   - pytorch
 dependencies:
   - python=3.11
@@ -18,7 +17,6 @@ dependencies:
   - ase
   - lightning
   - pytables
-  - dgl
   - pygments
   - numpy==1.26.4 # might need to install this after b/c of install order issues
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,16 +54,14 @@ channels = ["conda-forge", "defaults"]
 [tool.pip]
 # Custom pip dependencies or indexes can be specified here for documentation purposes.
 # To install with CUDA 12.4, use:
-# pip install torch==2.4.1 torchvision==0.15.2 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/cu124
-# pip install dgl --index-url https://data.dgl.ai/wheels/torch-2.4/cu124/repo.html
+# pip install torch==2.4.1 --index-url https://download.pytorch.org/whl/cu124
+# To install with ROCm 6.x, use:
+# pip install torch==2.4.1 --index-url https://download.pytorch.org/whl/rocm6.1
 dependencies = [
     "torch==2.4.1",
-    "dgl"
+    "torch_geometric"
 ]
-# The following index URLs are informational; pip only supports one --index-url per install command.
-# Use the appropriate index URL for each package as needed.
 index-urls = [
-    "https://download.pytorch.org/whl/cu124",
-    "https://data.dgl.ai/wheels/torch-2.4/cu124/repo.html"
+    "https://download.pytorch.org/whl/cu124"
 ]
 

--- a/qtaim_embed/core/datamodule.py
+++ b/qtaim_embed/core/datamodule.py
@@ -88,6 +88,7 @@ class QTAIMLinkTaskDataModule(pl.LightningDataModule):
                     map_key=self.config["dataset"]["map_key"],
                     verbose=self.config["dataset"]["verbose"],
                 num_workers=self.config["dataset"].get("num_workers", 1),
+                rbf_cutoff=self.config["dataset"].get("rbf_cutoff", 5.0),
                 )
                 validation = self.config["dataset"]["val_prop"]
                 test_size = self.config["dataset"]["test_prop"]
@@ -153,6 +154,7 @@ class QTAIMLinkTaskDataModule(pl.LightningDataModule):
                     ],
                     verbose=self.config["dataset"]["verbose"],
                 num_workers=self.config["dataset"].get("num_workers", 1),
+                rbf_cutoff=self.config["dataset"].get("rbf_cutoff", 5.0),
                 )
                 self.prepare_tf = True
                 if self.node_len is None:
@@ -274,6 +276,7 @@ class QTAIMNodeTaskDataModule(pl.LightningDataModule):
                     bond_key=self.config["dataset"]["bond_key"],
                     map_key=self.config["dataset"]["map_key"],
                 num_workers=self.config["dataset"].get("num_workers", 1),
+                rbf_cutoff=self.config["dataset"].get("rbf_cutoff", 5.0),
                 )
 
                 validation = self.config["dataset"]["val_prop"]
@@ -335,6 +338,7 @@ class QTAIMNodeTaskDataModule(pl.LightningDataModule):
                     bond_key=self.config["dataset"]["bond_key"],
                     map_key=self.config["dataset"]["map_key"],
                 num_workers=self.config["dataset"].get("num_workers", 1),
+                rbf_cutoff=self.config["dataset"].get("rbf_cutoff", 5.0),
                 )
                 self.prepare_tf = True
                 return (
@@ -439,6 +443,7 @@ class QTAIMGraphTaskDataModule(pl.LightningDataModule):
                     ],
                     verbose=self.config["dataset"]["verbose"],
                 num_workers=self.config["dataset"].get("num_workers", 1),
+                rbf_cutoff=self.config["dataset"].get("rbf_cutoff", 5.0),
                 )
 
                 validation = self.config["dataset"]["val_prop"]
@@ -507,6 +512,7 @@ class QTAIMGraphTaskDataModule(pl.LightningDataModule):
                     map_key=self.config["dataset"]["map_key"],
                     verbose=self.config["dataset"]["verbose"],
                 num_workers=self.config["dataset"].get("num_workers", 1),
+                rbf_cutoff=self.config["dataset"].get("rbf_cutoff", 5.0),
                 )
 
                 print("test set size: ", len(self.test_dataset))
@@ -619,6 +625,7 @@ class QTAIMGraphTaskClassifyDataModule(pl.LightningDataModule):
                     map_key=self.config["dataset"]["map_key"],
                     verbose=self.config["dataset"]["verbose"],
                 num_workers=self.config["dataset"].get("num_workers", 1),
+                rbf_cutoff=self.config["dataset"].get("rbf_cutoff", 5.0),
                 )
 
                 validation = self.config["dataset"]["val_prop"]
@@ -683,6 +690,7 @@ class QTAIMGraphTaskClassifyDataModule(pl.LightningDataModule):
                     map_key=self.config["dataset"]["map_key"],
                     verbose=self.config["dataset"]["verbose"],
                 num_workers=self.config["dataset"].get("num_workers", 1),
+                rbf_cutoff=self.config["dataset"].get("rbf_cutoff", 5.0),
                 )
                 print("test set size: ", len(self.test_dataset))
 

--- a/qtaim_embed/core/dataset.py
+++ b/qtaim_embed/core/dataset.py
@@ -70,6 +70,7 @@ class HeteroGraphNodeLabelDataset(torch.utils.data.Dataset):
         extra_dataset_info: Dict[str, Any] = {},
         num_workers: int = 1,
         verbose: bool = True,
+        rbf_cutoff: float = 5.0,
     ):
         """
         Baseline dataset for hetero graph node label prediction. Includes global feautures.
@@ -137,6 +138,7 @@ class HeteroGraphNodeLabelDataset(torch.utils.data.Dataset):
             allowed_charges=allowed_charges,
             allowed_spins=allowed_spins,
             self_loop=self_loop,
+            rbf_cutoff=rbf_cutoff,
         )
 
         # Build graphs - use parallel processing if num_workers > 1
@@ -212,6 +214,7 @@ class HeteroGraphNodeLabelDataset(torch.utils.data.Dataset):
         from qtaim_embed.data.parallel_utils import build_and_featurize_graph_worker
 
         # Extract grapher config for workers to reconstruct in each process
+        # NOTE: when adding new featurizer params, update all 3 _build_graphs_parallel sites
         grapher_config = {
             'element_set': grapher.atom_featurizer.element_set,
             'atom_keys': grapher.atom_featurizer.selected_keys,
@@ -221,6 +224,7 @@ class HeteroGraphNodeLabelDataset(torch.utils.data.Dataset):
             'allowed_charges': grapher.global_featurizer.allowed_charges,
             'allowed_spins': grapher.global_featurizer.allowed_spins,
             'self_loop': grapher.self_loop,
+            'rbf_cutoff': grapher.bond_featurizer.rbf_cutoff,
         }
 
         # Clamp workers to reasonable bounds
@@ -457,6 +461,7 @@ class HeteroGraphGraphLabelDataset(torch.utils.data.Dataset):
         extra_dataset_info: Dict[str, Any] = {},
         num_workers: int = 1,
         verbose: bool = True,
+        rbf_cutoff: float = 5.0,
     ):
         """
         Baseline dataset for hetero graph node label prediction. Includes global feautures.
@@ -533,6 +538,7 @@ class HeteroGraphGraphLabelDataset(torch.utils.data.Dataset):
             allowed_charges=allowed_charges,
             allowed_spins=allowed_spins,
             self_loop=self_loop,
+            rbf_cutoff=rbf_cutoff,
         )
 
         # Build graphs - use parallel processing if num_workers > 1
@@ -609,6 +615,7 @@ class HeteroGraphGraphLabelDataset(torch.utils.data.Dataset):
         from qtaim_embed.data.parallel_utils import build_and_featurize_graph_worker
 
         # Extract grapher config for workers to reconstruct in each process
+        # NOTE: when adding new featurizer params, update all 3 _build_graphs_parallel sites
         grapher_config = {
             'element_set': grapher.atom_featurizer.element_set,
             'atom_keys': grapher.atom_featurizer.selected_keys,
@@ -618,6 +625,7 @@ class HeteroGraphGraphLabelDataset(torch.utils.data.Dataset):
             'allowed_charges': grapher.global_featurizer.allowed_charges,
             'allowed_spins': grapher.global_featurizer.allowed_spins,
             'self_loop': grapher.self_loop,
+            'rbf_cutoff': grapher.bond_featurizer.rbf_cutoff,
         }
 
         # Clamp workers to reasonable bounds
@@ -862,6 +870,7 @@ class HeteroGraphGraphLabelClassifierDataset(torch.utils.data.Dataset):
         impute: bool = False,
         verbose: bool = True,
         num_workers: int = 1,
+        rbf_cutoff: float = 5.0,
     ):
         """
         Baseline dataset for hetero graph node label prediction. Includes global feautures.
@@ -930,6 +939,7 @@ class HeteroGraphGraphLabelClassifierDataset(torch.utils.data.Dataset):
             allowed_charges=allowed_charges,
             allowed_spins=allowed_spins,
             self_loop=self_loop,
+            rbf_cutoff=rbf_cutoff,
         )
 
         # Build graphs (parallel or serial)
@@ -991,6 +1001,7 @@ class HeteroGraphGraphLabelClassifierDataset(torch.utils.data.Dataset):
         from qtaim_embed.data.parallel_utils import build_and_featurize_graph_worker
 
         # Extract grapher config for workers (avoid pickling complex objects)
+        # NOTE: when adding new featurizer params, update all 3 _build_graphs_parallel sites
         grapher_config = {
             'element_set': grapher.atom_featurizer.element_set,
             'atom_keys': grapher.atom_featurizer.selected_keys,
@@ -1000,6 +1011,7 @@ class HeteroGraphGraphLabelClassifierDataset(torch.utils.data.Dataset):
             'allowed_charges': grapher.global_featurizer.allowed_charges,
             'allowed_spins': grapher.global_featurizer.allowed_spins,
             'self_loop': grapher.self_loop,
+            'rbf_cutoff': grapher.bond_featurizer.rbf_cutoff,
         }
 
         # Clamp workers to reasonable bounds

--- a/qtaim_embed/data/featurizer.py
+++ b/qtaim_embed/data/featurizer.py
@@ -12,6 +12,8 @@ from qtaim_embed.utils.descriptors import (
     ring_features_for_bonds_full,
     find_rings,
     get_node_direction_expansion,
+    sinusoidal_bessel_rbf,
+    gaussian_rbf,
 )
 from qtaim_embed.core.molwrapper import MoleculeWrapper
 
@@ -77,6 +79,7 @@ class BondAsNodeGraphFeaturizerGeneral(BaseFeaturizer):
         dtype: str = "float32",
         selected_keys: Optional[List[str]] = [],
         allowed_ring_size: Optional[List[int]] = [],
+        rbf_cutoff: float = 5.0,
     ):
         super(BaseFeaturizer, self).__init__()
         self._feature_size = 0
@@ -84,6 +87,7 @@ class BondAsNodeGraphFeaturizerGeneral(BaseFeaturizer):
         self.selected_keys = selected_keys
         self.dtype = dtype
         self.allowed_ring_size = allowed_ring_size
+        self.rbf_cutoff = rbf_cutoff
         if allowed_ring_size == []:
             print(
                 "NOTE: No ring size if no ring features are enabled, metal/nonmetal bonds are also off"
@@ -119,6 +123,28 @@ class BondAsNodeGraphFeaturizerGeneral(BaseFeaturizer):
             if "boo_" in key:
                 bool_boo = True
                 l_order = int(key.split("_")[1])
+
+        # Parse RBF config from selected_keys (only one RBF key supported)
+        bool_rbf = False
+        rbf_type = None
+        rbf_n_basis = 0
+        rbf_key_name = None
+        for key in self.selected_keys:
+            if "rbf_" in key:
+                bool_rbf = True
+                parts = key.split("_")  # "rbf_bessel_50" -> ["rbf", "bessel", "50"]
+                rbf_type = parts[1]
+                rbf_n_basis = int(parts[2])
+                rbf_key_name = key
+                break  # only one RBF key supported
+
+        # Fix num_feats for zero-bond fallback: BOO and RBF keys expand
+        # into multiple features, but count as 1 key each above.
+        # NOTE: when adding new featurizer params that expand keys, update here.
+        if bool_boo:
+            num_feats += (l_order + 1) ** 2 - 1
+        if bool_rbf:
+            num_feats += rbf_n_basis - 1
 
         if num_bonds == 0:
             ft = [0.0 for _ in range(num_feats)]
@@ -168,9 +194,29 @@ class BondAsNodeGraphFeaturizerGeneral(BaseFeaturizer):
                     boo_expansion = get_node_direction_expansion(dist, lmax=l_order)
                     ft += boo_expansion
 
+                if bool_rbf:
+                    bond_len_for_rbf = np.sqrt(
+                        np.sum(
+                            np.square(
+                                np.array(xyz_coordinates[bond[0]])
+                                - np.array(xyz_coordinates[bond[1]])
+                            )
+                        )
+                    )
+                    dist_tensor = torch.tensor([bond_len_for_rbf], dtype=torch.float32)
+                    if rbf_type == "bessel":
+                        expansion = sinusoidal_bessel_rbf(
+                            dist_tensor, rbf_n_basis, self.rbf_cutoff
+                        )
+                    elif rbf_type == "gaussian":
+                        expansion = gaussian_rbf(
+                            dist_tensor, rbf_n_basis, self.rbf_cutoff
+                        )
+                    ft += expansion.squeeze(0).tolist()
+
                 if self.selected_keys != None:
                     for key in self.selected_keys:
-                        if key != "bond_length" and "boo_" not in key:
+                        if key != "bond_length" and "boo_" not in key and "rbf_" not in key:
                             ft.append(features[bond][key])
 
                 feats.append(ft)
@@ -191,9 +237,13 @@ class BondAsNodeGraphFeaturizerGeneral(BaseFeaturizer):
             for l_num in range((l_order + 1) ** 2):
                 self._feature_name += ["boo_{}_{}".format(l_order, l_num)]
 
+        if bool_rbf:
+            for i in range(rbf_n_basis):
+                self._feature_name += ["{}_{}".format(rbf_key_name, i)]
+
         if self.selected_keys != []:
             for key in self.selected_keys:
-                if key != "bond_length" and "boo_" not in key:
+                if key != "bond_length" and "boo_" not in key and "rbf_" not in key:
                     self._feature_name.append(key)
 
             # self._feature_name += self.selected_keys

--- a/qtaim_embed/models/graph_level/base_gcn.py
+++ b/qtaim_embed/models/graph_level/base_gcn.py
@@ -395,6 +395,11 @@ class GCNGraphPred(pl.LightningModule):
             num_outputs=self.hparams.ntasks,
         )
 
+        if compiled and hasattr(torch.version, "hip") and torch.version.hip is not None:
+            import warnings
+            warnings.warn("torch.compile disabled on ROCm (no benefit, potential instability)")
+            compiled = False
+
         self.forward_fn = (
             torch.compile(self.compiled_forward, dynamic=True)
             if compiled

--- a/qtaim_embed/models/link_pred/link_model.py
+++ b/qtaim_embed/models/link_pred/link_model.py
@@ -273,6 +273,11 @@ class GCNLinkPred(pl.LightningModule):
 
         self.loss = self.loss_function()
 
+        if compiled and hasattr(torch.version, "hip") and torch.version.hip is not None:
+            import warnings
+            warnings.warn("torch.compile disabled on ROCm (no benefit, potential instability)")
+            compiled = False
+
         self.forward_fn = (
             torch.compile(self.compiled_forward, dynamic=True)
             if compiled

--- a/qtaim_embed/models/node_level/base_gcn.py
+++ b/qtaim_embed/models/node_level/base_gcn.py
@@ -270,6 +270,11 @@ class GCNNodePred(pl.LightningModule):
             torchmetrics.MeanSquaredError(squared=False), num_outputs=output_dims
         )
 
+        if compiled and hasattr(torch.version, "hip") and torch.version.hip is not None:
+            import warnings
+            warnings.warn("torch.compile disabled on ROCm (no benefit, potential instability)")
+            compiled = False
+
         self.forward_fn = (
             torch.compile(self.compiled_forward, dynamic=True)
             if compiled

--- a/qtaim_embed/scripts/helpers/mol2lmdb.py
+++ b/qtaim_embed/scripts/helpers/mol2lmdb.py
@@ -85,6 +85,7 @@ def main(argv=None):
         bond_key=config["dataset"]["bond_key"],
         map_key=config["dataset"]["map_key"],
         num_workers=num_workers,
+        rbf_cutoff=config["dataset"].get("rbf_cutoff", 5.0),
     )
 
     # Free MoleculeWrapper objects -- no longer needed after graph construction.

--- a/qtaim_embed/scripts/helpers/mol2lmdb_node.py
+++ b/qtaim_embed/scripts/helpers/mol2lmdb_node.py
@@ -91,6 +91,7 @@ def main(argv=None):
         bond_key=config["dataset"]["bond_key"],
         map_key=config["dataset"]["map_key"],
         num_workers=num_workers,
+        rbf_cutoff=config["dataset"].get("rbf_cutoff", 5.0),
     )
 
     if split == True:

--- a/qtaim_embed/scripts/train/train_qtaim_graph.py
+++ b/qtaim_embed/scripts/train/train_qtaim_graph.py
@@ -157,8 +157,8 @@ def main(argv=None):
         )
 
         # log dataset and optim settings from config
-        run.config.update(config["dataset"])
-        run.config.update(config["optim"])
+        run.config.update(config["dataset"], allow_val_change=True)
+        run.config.update(config["optim"], allow_val_change=True)
 
         trainer.fit(model, dm)
 

--- a/qtaim_embed/utils/data.py
+++ b/qtaim_embed/utils/data.py
@@ -98,7 +98,7 @@ def get_default_link_level_config():
             "precision": "bf16",
             "accumulate_grad_batches": 1,
             "pin_memory": True,
-            "persistent_workers": True,
+            "persistent_workers": False,
             "train_batch_size": 128,
         },
     }

--- a/qtaim_embed/utils/data.py
+++ b/qtaim_embed/utils/data.py
@@ -42,6 +42,7 @@ def get_default_link_level_config():
             "train_batch_size": 128,
             "test_dataset_loc": None,
             "train_dataset_loc": root + "/tests/data/labelled_data.pkl",
+            "rbf_cutoff": 5.0,
         },
         "model": {
             "classifier": False,
@@ -148,6 +149,7 @@ def get_default_node_level_config():
             "train_batch_size": 512,
             "test_dataset_loc": None,
             "train_dataset_loc": root + "/tests/data/labelled_data.pkl",
+            "rbf_cutoff": 5.0,
         },
         "model": {
             "classifier": False,
@@ -252,6 +254,7 @@ def get_default_graph_level_config():
 
             "impute": False,
             "verbose": False,
+            "rbf_cutoff": 5.0,
         },
         "model": {
             "classifier": False,
@@ -369,7 +372,7 @@ def get_default_graph_level_config_classif():
             "test_dataset_loc": None,
             "train_dataset_loc": root + "/tests/data/labelled_data.pkl",
             "num_workers": 1,
-
+            "rbf_cutoff": 5.0,
         },
         "model": {
             "classifier": True,

--- a/qtaim_embed/utils/descriptors.py
+++ b/qtaim_embed/utils/descriptors.py
@@ -54,7 +54,7 @@ def get_bond_features(
     bond_features = {}
 
     for key in keys:
-        if key != "bond_length" and "boo_" not in key:
+        if key != "bond_length" and "boo_" not in key and "rbf_" not in key:
             if type(row[key]) == int:
                 if row[key] == -1:
                     return -1
@@ -75,7 +75,7 @@ def get_bond_features(
             bond_index_map = row[map_key].index(tuple(bond))
 
         for key in keys:
-            if key != "bond_length" and "boo_" not in key:
+            if key != "bond_length" and "boo_" not in key and "rbf_" not in key:
                 if type(row[key][0]) == list:
                     bond_features[(bond[0], bond[1])][key] = row[key][0][bond_index_map]
                 else:
@@ -101,6 +101,87 @@ def get_node_direction_expansion(distance_vec: torch.Tensor, lmax: int) -> torch
 
     edge_sh = torch.abs(edge_sh)
     return edge_sh
+
+
+def sinusoidal_bessel_rbf(
+    distances: torch.Tensor,
+    n_basis: int,
+    cutoff: float,
+) -> torch.Tensor:
+    """Sinusoidal Bessel RBF expansion with polynomial envelope (p=5).
+
+    Computes orthogonal radial basis functions on [0, cutoff] using
+    the DimeNet formulation with an inlined p=5 polynomial envelope
+    for C^4 smoothness at the cutoff boundary.
+
+    Set cutoff near the max bond length in your dataset for best results.
+
+    Args:
+        distances: [N] tensor of interatomic distances in Angstroms
+        n_basis: number of basis functions
+        cutoff: cutoff radius in Angstroms
+
+    Returns:
+        [N, n_basis] tensor of RBF features
+    """
+    # Clamp to avoid sin(x)/x singularity at 0
+    d = distances.unsqueeze(-1)  # [N, 1]
+    d_clamped = torch.clamp(d, min=1e-8)
+
+    # Basis function indices [1, 2, ..., n_basis]
+    n = torch.arange(1, n_basis + 1, dtype=distances.dtype, device=distances.device)
+
+    # Bessel: sqrt(2/cutoff) * sin(n * pi * d / cutoff) / d
+    rbf = (
+        torch.sqrt(torch.tensor(2.0 / cutoff, dtype=distances.dtype))
+        * torch.sin(n * torch.pi * d_clamped / cutoff)
+        / d_clamped
+    )
+
+    # Polynomial envelope (p=5, inlined): 1 - 21*x^5 + 35*x^6 - 15*x^7
+    d_scaled = d / cutoff
+    envelope = 1.0 - 21.0 * d_scaled**5 + 35.0 * d_scaled**6 - 15.0 * d_scaled**7
+    envelope = torch.clamp(envelope, min=0.0)
+
+    rbf = rbf * envelope
+
+    # Zero out values beyond cutoff
+    mask = (d < cutoff).float()
+    rbf = rbf * mask
+
+    return rbf
+
+
+def gaussian_rbf(
+    distances: torch.Tensor,
+    n_basis: int,
+    cutoff: float,
+) -> torch.Tensor:
+    """Fixed Gaussian RBF expansion with evenly spaced centers.
+
+    Computes Gaussian radial basis functions with centers evenly distributed
+    over [0, cutoff] and width equal to the spacing between centers (SchNet
+    formulation).
+
+    Args:
+        distances: [N] tensor of interatomic distances in Angstroms
+        n_basis: number of basis functions
+        cutoff: cutoff radius in Angstroms
+
+    Returns:
+        [N, n_basis] tensor of RBF features
+    """
+    d = distances.unsqueeze(-1)  # [N, 1]
+
+    # Evenly spaced centers from 0 to cutoff
+    centers = torch.linspace(0.0, cutoff, n_basis, dtype=distances.dtype, device=distances.device)
+
+    # Width = spacing between centers
+    spacing = cutoff / (n_basis - 1) if n_basis > 1 else cutoff
+    gamma = 1.0 / (2.0 * spacing**2)
+
+    rbf = torch.exp(-gamma * (d - centers) ** 2)
+    return rbf
 
 
 def find_rings(

--- a/qtaim_embed/utils/grapher.py
+++ b/qtaim_embed/utils/grapher.py
@@ -21,6 +21,7 @@ def get_grapher(
     atom_featurizer_tf=True,
     bond_featurizer_tf=True,
     global_featurizer_tf=True,
+    rbf_cutoff=5.0,
 ):
     if not atom_featurizer_tf:
         atom_featurizer = None
@@ -37,6 +38,7 @@ def get_grapher(
         bond_featurizer = BondAsNodeGraphFeaturizerGeneral(
             selected_keys=bond_keys,
             allowed_ring_size=allowed_ring_size,
+            rbf_cutoff=rbf_cutoff,
         )
 
     if not global_featurizer_tf:

--- a/tests/test_featurizers.py
+++ b/tests/test_featurizers.py
@@ -332,3 +332,186 @@ class TestGrapher:
                 graph_list_charge[ind]["global"].feat.shape[1]
                 == graph_list_bare[ind]["global"].feat.shape[1] + 3
             )
+
+
+import torch
+from qtaim_embed.utils.descriptors import sinusoidal_bessel_rbf, gaussian_rbf
+
+
+class TestSinusoidalBesselRBF:
+    def test_output_shape(self):
+        d = torch.tensor([1.0, 2.0, 3.0])
+        out = sinusoidal_bessel_rbf(d, n_basis=20, cutoff=5.0)
+        assert out.shape == (3, 20)
+
+    def test_zero_at_cutoff(self):
+        d = torch.tensor([5.0])
+        out = sinusoidal_bessel_rbf(d, n_basis=20, cutoff=5.0)
+        assert torch.allclose(out, torch.zeros(1, 20), atol=1e-5)
+
+    def test_zero_distance_no_nan(self):
+        d = torch.tensor([0.0])
+        out = sinusoidal_bessel_rbf(d, n_basis=20, cutoff=5.0)
+        assert not torch.any(torch.isnan(out))
+
+    def test_beyond_cutoff_is_zero(self):
+        d = torch.tensor([6.0, 10.0])
+        out = sinusoidal_bessel_rbf(d, n_basis=20, cutoff=5.0)
+        assert torch.allclose(out, torch.zeros(2, 20), atol=1e-6)
+
+    def test_different_cutoffs(self):
+        d = torch.tensor([2.0])
+        out_5 = sinusoidal_bessel_rbf(d, n_basis=20, cutoff=5.0)
+        out_10 = sinusoidal_bessel_rbf(d, n_basis=20, cutoff=10.0)
+        assert not torch.allclose(out_5, out_10)
+
+    def test_nonzero_in_range(self):
+        d = torch.tensor([1.5])
+        out = sinusoidal_bessel_rbf(d, n_basis=20, cutoff=5.0)
+        assert out.abs().sum() > 0
+
+
+class TestGaussianRBF:
+    def test_output_shape(self):
+        d = torch.tensor([1.0, 2.0])
+        out = gaussian_rbf(d, n_basis=50, cutoff=5.0)
+        assert out.shape == (2, 50)
+
+    def test_peak_at_center(self):
+        n_basis = 10
+        cutoff = 5.0
+        centers = torch.linspace(0, cutoff, n_basis)
+        for i, c in enumerate(centers):
+            out = gaussian_rbf(c.unsqueeze(0), n_basis, cutoff)
+            assert out[0, i] == out[0].max()
+
+    def test_bounded_output(self):
+        d = torch.linspace(0, 10, 100)
+        out = gaussian_rbf(d, n_basis=50, cutoff=5.0)
+        assert out.min() >= 0.0
+        assert out.max() <= 1.0 + 1e-6
+
+    def test_nonzero_in_range(self):
+        d = torch.tensor([2.5])
+        out = gaussian_rbf(d, n_basis=20, cutoff=5.0)
+        assert out.abs().sum() > 0
+
+
+class TestRBFFeaturizerIntegration:
+    df_test = get_data()
+
+    def test_rbf_bessel_featurizer(self):
+        atom_keys = ["extra_feat_atom_esp_total"]
+        bond_keys = ["rbf_bessel_20"]
+        mol_wrappers, element_set = mol_wrappers_from_df(
+            df=self.df_test,
+            bond_key="bonds",
+            map_key="extra_feat_bond_indices_qtaim",
+            atom_keys=atom_keys,
+            bond_keys=bond_keys,
+            global_keys=[],
+        )
+        grapher = get_grapher(
+            element_set,
+            atom_keys=atom_keys,
+            bond_keys=bond_keys,
+            global_keys=[],
+            allowed_ring_size=[3, 4, 5, 6, 7],
+            self_loop=True,
+            rbf_cutoff=5.0,
+        )
+        for mol in mol_wrappers:
+            graph = grapher.build_graph(mol)
+            graph, names = grapher.featurize(graph, mol, ret_feat_names=True)
+            bond_names = names["bond"]
+            # Should have ring features (7) + 20 RBF features
+            rbf_names = [n for n in bond_names if "rbf_bessel_20" in n]
+            assert len(rbf_names) == 20
+            assert "rbf_bessel_20_0" in bond_names
+            assert "rbf_bessel_20_19" in bond_names
+
+    def test_rbf_gaussian_featurizer(self):
+        atom_keys = ["extra_feat_atom_esp_total"]
+        bond_keys = ["rbf_gaussian_10"]
+        mol_wrappers, element_set = mol_wrappers_from_df(
+            df=self.df_test,
+            bond_key="bonds",
+            map_key="extra_feat_bond_indices_qtaim",
+            atom_keys=atom_keys,
+            bond_keys=bond_keys,
+            global_keys=[],
+        )
+        grapher = get_grapher(
+            element_set,
+            atom_keys=atom_keys,
+            bond_keys=bond_keys,
+            global_keys=[],
+            allowed_ring_size=[3, 4, 5, 6, 7],
+            self_loop=True,
+            rbf_cutoff=5.0,
+        )
+        for mol in mol_wrappers:
+            graph = grapher.build_graph(mol)
+            graph, names = grapher.featurize(graph, mol, ret_feat_names=True)
+            bond_names = names["bond"]
+            rbf_names = [n for n in bond_names if "rbf_gaussian_10" in n]
+            assert len(rbf_names) == 10
+
+    def test_rbf_plus_boo_featurizer(self):
+        atom_keys = ["extra_feat_atom_esp_total"]
+        bond_keys = ["rbf_bessel_10", "boo_2"]
+        mol_wrappers, element_set = mol_wrappers_from_df(
+            df=self.df_test,
+            bond_key="bonds",
+            map_key="extra_feat_bond_indices_qtaim",
+            atom_keys=atom_keys,
+            bond_keys=bond_keys,
+            global_keys=[],
+        )
+        grapher = get_grapher(
+            element_set,
+            atom_keys=atom_keys,
+            bond_keys=bond_keys,
+            global_keys=[],
+            allowed_ring_size=[3, 4, 5, 6, 7],
+            self_loop=True,
+            rbf_cutoff=5.0,
+        )
+        for mol in mol_wrappers:
+            graph = grapher.build_graph(mol)
+            graph, names = grapher.featurize(graph, mol, ret_feat_names=True)
+            bond_names = names["bond"]
+            rbf_names = [n for n in bond_names if "rbf_bessel_10" in n]
+            boo_names = [n for n in bond_names if "boo_2" in n]
+            assert len(rbf_names) == 10
+            assert len(boo_names) == 9  # (2+1)^2 = 9
+
+    def test_no_rbf_backward_compatible(self):
+        atom_keys = ["extra_feat_atom_esp_total"]
+        bond_keys = ["extra_feat_bond_esp_total", "bond_length"]
+        mol_wrappers, element_set = mol_wrappers_from_df(
+            df=self.df_test,
+            bond_key="bonds",
+            map_key="extra_feat_bond_indices_qtaim",
+            atom_keys=atom_keys,
+            bond_keys=bond_keys,
+            global_keys=[],
+        )
+        grapher = get_grapher(
+            element_set,
+            atom_keys=atom_keys,
+            bond_keys=bond_keys,
+            global_keys=[],
+            allowed_ring_size=[3, 4, 5, 6, 7],
+            self_loop=True,
+        )
+        for mol in mol_wrappers:
+            graph = grapher.build_graph(mol)
+            graph, names = grapher.featurize(graph, mol, ret_feat_names=True)
+            bond_names = names["bond"]
+            # Should have ring features (7) + bond_length (1) + esp_total (1) = 9
+            assert "bond_length" in bond_names
+            assert "extra_feat_bond_esp_total" in bond_names
+            # No RBF names
+            rbf_names = [n for n in bond_names if "rbf_" in n]
+            assert len(rbf_names) == 0

--- a/tests/test_featurizers.py
+++ b/tests/test_featurizers.py
@@ -515,3 +515,34 @@ class TestRBFFeaturizerIntegration:
             # No RBF names
             rbf_names = [n for n in bond_names if "rbf_" in n]
             assert len(rbf_names) == 0
+
+    def test_zero_bond_molecule_with_rbf(self):
+        """Zero-bond fallback path produces correct feature width when RBF is enabled."""
+        import numpy as np
+        from qtaim_embed.data.featurizer import BondAsNodeGraphFeaturizerGeneral
+
+        n_basis = 16
+        bond_keys = ["rbf_bessel_16"]
+
+        # Minimal mock that satisfies the featurizer interface
+        class MockMol:
+            bonds = {}
+            bond_features = {}
+            coords = np.zeros((1, 3))
+            num_atoms = 1
+
+        featurizer = BondAsNodeGraphFeaturizerGeneral(
+            selected_keys=bond_keys,
+            allowed_ring_size=[3, 4, 5, 6, 7],
+            rbf_cutoff=5.0,
+        )
+
+        feats, names = featurizer(MockMol())
+        bond_feat_tensor = feats["feat"]
+
+        # num_feats = len(selected_keys)=1 + 7 (ring/metal) + (n_basis-1)=15 = 23
+        expected_width = 1 + 7 + (n_basis - 1)
+        assert bond_feat_tensor.shape == (1, expected_width), (
+            f"Expected shape (1, {expected_width}), got {bond_feat_tensor.shape}"
+        )
+        assert not torch.any(torch.isnan(bond_feat_tensor))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -330,3 +330,61 @@ def test_multi_task():
     )
 
     trainer.fit(model, data_loader)
+
+
+def test_train_with_rbf_features():
+    """End-to-end: dataset with RBF bond features trains without error."""
+    from pathlib import Path
+    from qtaim_embed.core.dataset import HeteroGraphGraphLabelDataset
+
+    data_file = str(Path(__file__).parent / "data" / "labelled_data.pkl")
+
+    dataset = HeteroGraphGraphLabelDataset(
+        file=data_file,
+        allowed_ring_size=[3, 4, 5, 6, 7],
+        allowed_charges=None,
+        allowed_spins=None,
+        self_loop=True,
+        element_set=[],
+        extra_keys={
+            "atom": ["extra_feat_atom_esp_total"],
+            "bond": ["rbf_bessel_10"],
+            "global": ["extra_feat_global_E1_CAM"],
+        },
+        target_list=["extra_feat_global_E1_CAM"],
+        extra_dataset_info={},
+        debug=True,
+        log_scale_features=False,
+        log_scale_targets=False,
+        standard_scale_features=True,
+        standard_scale_targets=True,
+        bond_key="bonds",
+        map_key="extra_feat_bond_indices_qtaim",
+        rbf_cutoff=5.0,
+    )
+
+    data_loader = DataLoaderMoleculeGraphTask(
+        dataset, batch_size=len(dataset.graphs), shuffle=False
+    )
+
+    model_config = get_default_graph_level_config()
+    model_config["model"]["atom_feature_size"] = dataset.feature_size["atom"]
+    model_config["model"]["bond_feature_size"] = dataset.feature_size["bond"]
+    model_config["model"]["global_feature_size"] = dataset.feature_size["global"]
+    model_config["model"]["target_dict"]["global"] = dataset.target_dict["global"]
+    model_config["model"]["initializer"] = None
+
+    model = load_graph_level_model_from_config(model_config["model"])
+
+    trainer = pl.Trainer(
+        max_epochs=2,
+        accelerator="auto",
+        devices=1,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        log_every_n_steps=1,
+    )
+    trainer.fit(model, data_loader)
+
+    # verify bond feature width: 7 ring features + 10 RBF = 17
+    assert dataset.feature_size["bond"] == 17


### PR DESCRIPTION
## Summary

- Adds configurable RBF distance expansion for bond features via `rbf_bessel_N` / `rbf_gaussian_N` keys in `extra_keys["bond"]` and `rbf_cutoff` config param
- Implements sinusoidal Bessel (DimeNet-style, p=5 envelope) and Gaussian (SchNet-style) basis functions in `utils/descriptors.py`
- Fixes zero-bond molecule fallback in `BondAsNodeGraphFeaturizerGeneral` when RBF keys are present
- Passes `rbf_cutoff` from config through `mol2lmdb` helpers
- Disables `torch.compile` on ROCm/HIP across all three model classes (no benefit, potential instability)
- Fixes `persistent_workers=False` in default link-level config (prevents SIGSEGV after ~34K samples)
- Removes DGL from `env.yml`/`pyproject.toml`; adds ROCm install instructions

## Test plan

- [x] `TestSinusoidalBesselRBF` / `TestGaussianRBF` -- 10 unit tests on basis functions
- [x] `TestRBFFeaturizerIntegration` -- bessel, gaussian, RBF+BOO, backward compat, zero-bond fallback
- [x] `test_train_with_rbf_features` -- end-to-end train with `rbf_bessel_10`
- [x] `test_lmdb_link::test_model_lmdb` -- passes with `persistent_workers=False`
- [x] Full suite: `pytest tests/` -- all pass
