### PR TITLE
Feature/iterative link node predictor

### DIFF
--- a/qtaim_embed/data/lmdb.py
+++ b/qtaim_embed/data/lmdb.py
@@ -396,6 +396,19 @@ def open_lmdb_readonly(path: str):
     )
 
 
+_LMDB_METADATA_KEYS = {b"length", b"feature_size", b"feature_names", b"element_set",
+                        b"allowed_ring_size", b"allowed_charges", b"allowed_spins",
+                        b"target_dict", b"extra_dataset_info", b"log_scale_features",
+                        b"length_chunk", b"scaled", b"processed_source_keys",
+                        b"scaler_finalized"}
+
+# Metadata copied verbatim into each split LMDB so the dataloader works.
+# Derived from _LMDB_METADATA_KEYS minus per-split bookkeeping ("length" is
+# rewritten per split) and scaling state (a fresh split is unscaled).
+_COPY_META = _LMDB_METADATA_KEYS - {b"length", b"length_chunk", b"scaled",
+                                    b"processed_source_keys", b"scaler_finalized"}
+
+
 def write_lmdb_split(src_env, keys: list, out_path: str) -> None:
     """
     Write one split (train/val/test) from a source LMDB.
@@ -442,9 +455,6 @@ def write_lmdb_split(src_env, keys: list, out_path: str) -> None:
     txn = db.begin(write=True)
     txn.put("length".encode("ascii"), pickle.dumps(len(keys), protocol=-1))
     # Copy dataset metadata so LMDBMoleculeDataset.feature_names/feature_size/target_dict work
-    _COPY_META = {b"feature_size", b"feature_names", b"element_set", b"allowed_ring_size",
-                  b"allowed_charges", b"allowed_spins", b"target_dict",
-                  b"extra_dataset_info", b"log_scale_features"}
     with src_env.begin() as src_txn:
         for meta_key in _COPY_META:
             val = src_txn.get(meta_key)
@@ -453,13 +463,6 @@ def write_lmdb_split(src_env, keys: list, out_path: str) -> None:
     txn.commit()
     db.sync()
     db.close()
-
-
-_LMDB_METADATA_KEYS = {b"length", b"feature_size", b"feature_names", b"element_set",
-                        b"allowed_ring_size", b"allowed_charges", b"allowed_spins",
-                        b"target_dict", b"extra_dataset_info", b"log_scale_features",
-                        b"length_chunk", b"scaled", b"processed_source_keys",
-                        b"scaler_finalized"}
 
 
 def _assign_formula_to_split(formula: str, ratios, seed: int) -> int:
@@ -573,6 +576,15 @@ def split_lmdb_file(
     else:  # composition
         with src_env.begin() as txn:
             fn_raw = txn.get(b"feature_names")
+            scaled_raw = txn.get(b"scaled")
+        # composition needs raw 0/1 one-hot element columns; scaled features
+        # turn them into standardized floats and silently corrupt formulas.
+        if scaled_raw is not None and pickle.loads(scaled_raw):
+            raise ValueError(
+                "composition split requires unscaled features (chemical_symbol_* columns "
+                "must be 0/1 one-hots), but the source LMDB is marked scaled. "
+                "Run the composition split before scaling."
+            )
         if fn_raw is None:
             raise ValueError(
                 "composition split requires 'feature_names' metadata in the source LMDB"
@@ -586,19 +598,44 @@ def split_lmdb_file(
         ratios = (1.0 - val_prop - test_prop, val_prop, test_prop)
         split_names = ("train", "val", "test")
         by_formula = {}
+        n_failed = 0
+        n_empty = 0
         with src_env.begin() as txn:
             for k in tqdm(all_keys, desc="deriving formulas"):
-                obj = pickle.loads(txn.get(k))
-                graph_bytes = obj["molecule_graph"] if isinstance(obj, dict) else obj
-                graph = (
-                    load_graph_from_serialized(graph_bytes)
-                    if isinstance(graph_bytes, (bytes, bytearray))
-                    else graph_bytes
-                )
-                by_formula.setdefault(_formula_from_graph(graph, elem_cols), []).append(k)
+                try:
+                    obj = pickle.loads(txn.get(k))
+                    graph_bytes = obj["molecule_graph"] if isinstance(obj, dict) else obj
+                    graph = (
+                        load_graph_from_serialized(graph_bytes)
+                        if isinstance(graph_bytes, (bytes, bytearray))
+                        else graph_bytes
+                    )
+                    formula = _formula_from_graph(graph, elem_cols)
+                except Exception as e:
+                    # a single bad record must not abort the whole split; route to train
+                    logger.warning(
+                        f"composition split: formula derivation failed for key {k!r}: {e}; "
+                        "routing to train"
+                    )
+                    formula = ""
+                    n_failed += 1
+                else:
+                    if formula == "":
+                        n_empty += 1
+                by_formula.setdefault(formula, []).append(k)
         splits = {name: [] for name in split_names}
         for formula, group in by_formula.items():
-            splits[split_names[_assign_formula_to_split(formula, ratios, seed)]].extend(group)
+            # empty/failed formulas go to train, matching the converter --split path
+            # (qtaim_gen.partition_keys_by_composition routes missing formulas to train).
+            if formula == "":
+                splits["train"].extend(group)
+            else:
+                splits[split_names[_assign_formula_to_split(formula, ratios, seed)]].extend(group)
+        if n_failed or n_empty:
+            logger.info(
+                f"composition split: routed {n_failed} failed + {n_empty} empty-formula "
+                "molecules to train"
+            )
         logger.info(
             f"composition split: {n} molecules across {len(by_formula)} unique formulas"
         )

--- a/qtaim_embed/data/lmdb.py
+++ b/qtaim_embed/data/lmdb.py
@@ -2,6 +2,7 @@ import logging
 import os
 import io
 import shutil
+import hashlib
 import lmdb
 import pickle
 import torch
@@ -440,6 +441,15 @@ def write_lmdb_split(src_env, keys: list, out_path: str) -> None:
 
     txn = db.begin(write=True)
     txn.put("length".encode("ascii"), pickle.dumps(len(keys), protocol=-1))
+    # Copy dataset metadata so LMDBMoleculeDataset.feature_names/feature_size/target_dict work
+    _COPY_META = {b"feature_size", b"feature_names", b"element_set", b"allowed_ring_size",
+                  b"allowed_charges", b"allowed_spins", b"target_dict",
+                  b"extra_dataset_info", b"log_scale_features"}
+    with src_env.begin() as src_txn:
+        for meta_key in _COPY_META:
+            val = src_txn.get(meta_key)
+            if val is not None:
+                txn.put(meta_key, val)
     txn.commit()
     db.sync()
     db.close()
@@ -448,7 +458,64 @@ def write_lmdb_split(src_env, keys: list, out_path: str) -> None:
 _LMDB_METADATA_KEYS = {b"length", b"feature_size", b"feature_names", b"element_set",
                         b"allowed_ring_size", b"allowed_charges", b"allowed_spins",
                         b"target_dict", b"extra_dataset_info", b"log_scale_features",
-                        b"length_chunk"}
+                        b"length_chunk", b"scaled", b"processed_source_keys",
+                        b"scaler_finalized"}
+
+
+def _assign_formula_to_split(formula: str, ratios, seed: int) -> int:
+    """Deterministically map a formula string to a split index (0/1/2).
+
+    Mirrors qtaim_gen.source.utils.splits.assign_formula_to_split exactly
+    (SHA-256 of "{formula}_{seed}" -> [0, 1) -> cumulative-ratio bucket) so
+    composition splits produced here match the converter --split path.
+    Reimplemented rather than imported because qtaim_gen depends on
+    qtaim_embed; importing it here would be a circular dependency.
+    """
+    hash_input = f"{formula}_{seed}"
+    hash_val = int(hashlib.sha256(hash_input.encode()).hexdigest(), 16) % 10000 / 10000.0
+    cumulative = 0.0
+    for i, ratio in enumerate(ratios):
+        cumulative += ratio
+        if hash_val < cumulative:
+            return i
+    return len(ratios) - 1
+
+
+def _element_columns_from_feature_names(feature_names) -> list:
+    """Return [(col_index, element_symbol), ...] for chemical_symbol_* atom feats."""
+    atom_names = feature_names.get("atom", []) if isinstance(feature_names, dict) else []
+    prefix = "chemical_symbol_"
+    return [
+        (i, name[len(prefix):])
+        for i, name in enumerate(atom_names)
+        if isinstance(name, str) and name.startswith(prefix)
+    ]
+
+
+def _formula_from_graph(graph, elem_cols) -> str:
+    """Reconstruct a pymatgen formula string from atom element one-hot columns.
+
+    Sums each chemical_symbol_* one-hot column across atoms to recover element
+    counts, then formats via pymatgen Composition so the string matches
+    build_formula_map_from_structure_lmdb's convention.
+    """
+    from pymatgen.core import Composition
+
+    feat = graph["atom"].feat
+    width = feat.shape[1]
+    counts = {}
+    for idx, sym in elem_cols:
+        if idx >= width:
+            raise ValueError(
+                f"element column index {idx} ({sym}) exceeds atom.feat width {width}; "
+                "feature_names does not align with stored graphs"
+            )
+        c = int(round(float(feat[:, idx].sum().item())))
+        if c > 0:
+            counts[sym] = c
+    if not counts:
+        return ""
+    return Composition(counts).formula.replace(" ", "")
 
 
 def split_lmdb_file(
@@ -458,15 +525,28 @@ def split_lmdb_file(
     test_prop: float = 0.1,
     seed: int = 42,
     lmdb_name: str = "data.lmdb",
+    method: str = "random",
 ) -> dict:
     """
     Split a single LMDB into train/val/test LMDBs.
+
+    method:
+      "random"      -- uniform shuffle by key (default; backward compatible).
+      "composition" -- group by molecular formula (derived from each graph's
+                       chemical_symbol_* one-hot columns) and assign whole
+                       formula groups to a split via a deterministic hash.
+                       All molecules sharing a formula land in the same split,
+                       which prevents leakage between near-identical structures
+                       (e.g. trajectory steps of one system). Requires
+                       'feature_names' metadata in the source LMDB.
 
     Returns a dict with keys "train", "val", "test" mapping to output paths
     and "sizes" mapping to {"train": int, "val": int, "test": int}.
     """
     if val_prop + test_prop >= 1.0:
         raise ValueError(f"val_prop + test_prop must be < 1.0, got {val_prop + test_prop}")
+    if method not in ("random", "composition"):
+        raise ValueError(f"method must be 'random' or 'composition', got {method!r}")
 
     src_env = open_lmdb_readonly(src_path)
     stat = src_env.stat()
@@ -479,20 +559,54 @@ def split_lmdb_file(
         ]
     n = len(all_keys)
 
-    rng = _random.Random(seed)
-    rng.shuffle(all_keys)
+    if method == "random":
+        rng = _random.Random(seed)
+        rng.shuffle(all_keys)
+        n_test = int(n * test_prop)
+        n_val = int(n * val_prop)
+        n_train = n - n_val - n_test
+        splits = {
+            "train": all_keys[:n_train],
+            "val": all_keys[n_train : n_train + n_val],
+            "test": all_keys[n_train + n_val :],
+        }
+    else:  # composition
+        with src_env.begin() as txn:
+            fn_raw = txn.get(b"feature_names")
+        if fn_raw is None:
+            raise ValueError(
+                "composition split requires 'feature_names' metadata in the source LMDB"
+            )
+        elem_cols = _element_columns_from_feature_names(pickle.loads(fn_raw))
+        if not elem_cols:
+            raise ValueError(
+                "no 'chemical_symbol_*' columns found in atom feature_names; "
+                "cannot derive formulas for composition split"
+            )
+        ratios = (1.0 - val_prop - test_prop, val_prop, test_prop)
+        split_names = ("train", "val", "test")
+        by_formula = {}
+        with src_env.begin() as txn:
+            for k in tqdm(all_keys, desc="deriving formulas"):
+                obj = pickle.loads(txn.get(k))
+                graph_bytes = obj["molecule_graph"] if isinstance(obj, dict) else obj
+                graph = (
+                    load_graph_from_serialized(graph_bytes)
+                    if isinstance(graph_bytes, (bytes, bytearray))
+                    else graph_bytes
+                )
+                by_formula.setdefault(_formula_from_graph(graph, elem_cols), []).append(k)
+        splits = {name: [] for name in split_names}
+        for formula, group in by_formula.items():
+            splits[split_names[_assign_formula_to_split(formula, ratios, seed)]].extend(group)
+        logger.info(
+            f"composition split: {n} molecules across {len(by_formula)} unique formulas"
+        )
 
-    n_test = int(n * test_prop)
-    n_val = int(n * val_prop)
-    n_train = n - n_val - n_test
-
+    n_train = len(splits["train"])
+    n_val = len(splits["val"])
+    n_test = len(splits["test"])
     logger.info(f"Total molecules: {n}  ->  train={n_train}, val={n_val}, test={n_test}")
-
-    splits = {
-        "train": all_keys[:n_train],
-        "val": all_keys[n_train : n_train + n_val],
-        "test": all_keys[n_train + n_val :],
-    }
 
     out_paths = {}
     for split_name, keys in splits.items():

--- a/qtaim_embed/scripts/helpers/split_lmdb.py
+++ b/qtaim_embed/scripts/helpers/split_lmdb.py
@@ -27,6 +27,15 @@ def main():
     parser.add_argument("--test_prop", type=float, default=0.1)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--lmdb_name", type=str, default="data.lmdb")
+    parser.add_argument(
+        "--method",
+        type=str,
+        default="random",
+        choices=["random", "composition"],
+        help="random: uniform shuffle by key. composition: group by molecular "
+        "formula so same-formula molecules share a split (prevents leakage "
+        "between near-identical structures such as trajectory steps).",
+    )
     args = parser.parse_args()
 
     result = split_lmdb_file(
@@ -36,6 +45,7 @@ def main():
         test_prop=args.test_prop,
         seed=args.seed,
         lmdb_name=args.lmdb_name,
+        method=args.method,
     )
 
     sizes = result["sizes"]

--- a/tests/test_split_lmdb.py
+++ b/tests/test_split_lmdb.py
@@ -9,6 +9,7 @@ import torch
 from torch_geometric.data import HeteroData
 
 from qtaim_embed.data.lmdb import (
+    _LMDB_METADATA_KEYS,
     load_graph_from_serialized,
     open_lmdb_readonly,
     split_lmdb_file,
@@ -123,10 +124,10 @@ class TestSplitLmdbFile:
 
         env = open_lmdb_readonly(result["train"])
         with env.begin() as txn:
-            keys = [k.decode("ascii") for k, _ in txn.cursor()]
+            keys = [k for k, _ in txn.cursor()]
         env.close()
 
-        non_meta = [k for k in keys if k != "length"]
+        non_meta = [k.decode("ascii") for k in keys if k not in _LMDB_METADATA_KEYS]
         assert all(k.isdigit() for k in non_meta)
         assert sorted(int(k) for k in non_meta) == list(range(len(non_meta)))
 
@@ -240,6 +241,43 @@ class TestSplitLmdbEdgeCases:
         captured = capsys.readouterr()
         assert "train" in captured.err or "val" in captured.err or "test" in captured.err
 
+    def test_metadata_propagated_to_splits(self, tmp_path):
+        """Metadata keys written to source LMDB are copied to every split."""
+        src = str(tmp_path / "src.lmdb")
+        n = 30
+        feature_names = {"atom": ["feat_a"], "bond": ["feat_b"], "global": []}
+        feature_size = {"atom": 1, "bond": 1, "global": 0}
+        target_dict = {"atom": ["label_x"], "bond": [], "global": []}
+        element_set = {"C", "H", "O"}
+
+        db = lmdb.open(src, map_size=10 ** 8, subdir=False, meminit=False, map_async=True)
+        for i in range(n):
+            graph_bytes = _serialize(_make_graph())
+            val = pickle.dumps({"molecule_graph": graph_bytes}, protocol=-1)
+            txn = db.begin(write=True)
+            txn.put(f"{i}".encode("ascii"), val)
+            txn.commit()
+        txn = db.begin(write=True)
+        txn.put(b"length", pickle.dumps(n, protocol=-1))
+        txn.put(b"feature_names", pickle.dumps(feature_names, protocol=-1))
+        txn.put(b"feature_size", pickle.dumps(feature_size, protocol=-1))
+        txn.put(b"target_dict", pickle.dumps(target_dict, protocol=-1))
+        txn.put(b"element_set", pickle.dumps(element_set, protocol=-1))
+        txn.commit()
+        db.sync()
+        db.close()
+
+        result = split_lmdb_file(src, str(tmp_path / "out"), val_prop=0.2, test_prop=0.1, seed=0)
+
+        for split_path in (result["train"], result["val"], result["test"]):
+            env = open_lmdb_readonly(split_path)
+            with env.begin() as txn:
+                assert pickle.loads(txn.get(b"feature_names")) == feature_names
+                assert pickle.loads(txn.get(b"feature_size")) == feature_size
+                assert pickle.loads(txn.get(b"target_dict")) == target_dict
+                assert pickle.loads(txn.get(b"element_set")) == element_set
+            env.close()
+
 
 class TestWriteLmdbSplitEmbedFormat:
     def test_embed_format_passthrough(self, tmp_path):
@@ -262,3 +300,149 @@ class TestWriteLmdbSplitEmbedFormat:
         assert "molecule_graph" in obj
         graph = load_graph_from_serialized(obj["molecule_graph"])
         assert hasattr(graph["atom"], "feat")
+
+
+# ---------------------------------------------------------------------------
+# Tests: composition-based splitting
+# ---------------------------------------------------------------------------
+
+def _make_composition_graph(counts: dict, elem_order: list) -> HeteroData:
+    """Build a graph whose atom.feat element one-hots encode `counts`."""
+    n_elem = len(elem_order)
+    rows = []
+    for sym, c in counts.items():
+        onehot = [1.0 if e == sym else 0.0 for e in elem_order]
+        rows.extend([[0.0, 0.0] + onehot for _ in range(c)])
+    feat = torch.tensor(rows, dtype=torch.float32)
+    n_atoms = feat.shape[0]
+    g = HeteroData()
+    g["atom"].feat = feat
+    g["atom"].num_nodes = n_atoms
+    g["bond"].feat = torch.zeros(max(n_atoms - 1, 1), 3)
+    g["bond"].num_nodes = max(n_atoms - 1, 1)
+    g["global"].feat = torch.zeros(1, 2)
+    g["global"].num_nodes = 1
+    return g
+
+
+def _make_composition_lmdb(path: str, formulas: list, elem_order: list) -> None:
+    """Embed-format LMDB with element one-hot atom feats + feature_names metadata.
+
+    `formulas` is one dict of element counts per molecule.
+    """
+    atom_feature_names = ["total_degree", "total_H"] + [
+        f"chemical_symbol_{e}" for e in elem_order
+    ]
+    feature_names = {"atom": atom_feature_names, "bond": ["b0", "b1", "b2"], "global": ["g0", "g1"]}
+
+    db = lmdb.open(path, map_size=10 ** 8, subdir=False, meminit=False, map_async=True)
+    for i, counts in enumerate(formulas):
+        graph_bytes = _serialize(_make_composition_graph(counts, elem_order))
+        val = pickle.dumps({"molecule_graph": graph_bytes}, protocol=-1)
+        txn = db.begin(write=True)
+        txn.put(f"{i}".encode("ascii"), val)
+        txn.commit()
+    txn = db.begin(write=True)
+    txn.put(b"length", pickle.dumps(len(formulas), protocol=-1))
+    txn.put(b"feature_names", pickle.dumps(feature_names, protocol=-1))
+    txn.commit()
+    db.sync()
+    db.close()
+
+
+class TestCompositionSplit:
+    ELEMS = ["C", "H", "O", "N"]
+    # five distinct formulas, several molecules each
+    FORMULAS = (
+        [{"C": 1, "H": 4}] * 6
+        + [{"C": 2, "H": 6}] * 6
+        + [{"C": 1, "H": 2, "O": 1}] * 6
+        + [{"N": 2}] * 6
+        + [{"O": 2, "H": 2}] * 6
+    )
+
+    def _split_membership(self, result):
+        """Return {key: split_name} across all three split LMDBs."""
+        membership = {}
+        for split_name in ("train", "val", "test"):
+            env = open_lmdb_readonly(result[split_name])
+            with env.begin() as txn:
+                for k, v in txn.cursor():
+                    if k in _LMDB_METADATA_KEYS:
+                        continue
+                    g = load_graph_from_serialized(pickle.loads(v)["molecule_graph"])
+                    # recover formula signature from element one-hot sums
+                    feat = g["atom"].feat
+                    sig = tuple(int(feat[:, 2 + j].sum().item()) for j in range(len(self.ELEMS)))
+                    membership[(split_name, k)] = sig
+            env.close()
+        return membership
+
+    def test_same_formula_lands_in_one_split(self, tmp_path):
+        src = str(tmp_path / "src.lmdb")
+        _make_composition_lmdb(src, self.FORMULAS, self.ELEMS)
+        result = split_lmdb_file(
+            src, str(tmp_path / "out"), val_prop=0.2, test_prop=0.2,
+            seed=7, method="composition",
+        )
+        # map each formula signature -> set of splits it appears in
+        sig_to_splits = {}
+        for (split_name, _key), sig in self._split_membership(result).items():
+            sig_to_splits.setdefault(sig, set()).add(split_name)
+        # every formula must appear in exactly one split
+        for sig, splits in sig_to_splits.items():
+            assert len(splits) == 1, f"formula {sig} leaked across splits {splits}"
+
+    def test_composition_deterministic(self, tmp_path):
+        src = str(tmp_path / "src.lmdb")
+        _make_composition_lmdb(src, self.FORMULAS, self.ELEMS)
+        r1 = split_lmdb_file(src, str(tmp_path / "o1"), val_prop=0.2, test_prop=0.2,
+                             seed=7, method="composition")
+        r2 = split_lmdb_file(src, str(tmp_path / "o2"), val_prop=0.2, test_prop=0.2,
+                             seed=7, method="composition")
+        assert r1["sizes"] == r2["sizes"]
+
+    def test_total_preserved(self, tmp_path):
+        src = str(tmp_path / "src.lmdb")
+        _make_composition_lmdb(src, self.FORMULAS, self.ELEMS)
+        result = split_lmdb_file(src, str(tmp_path / "out"), val_prop=0.2, test_prop=0.2,
+                                 seed=7, method="composition")
+        sizes = result["sizes"]
+        assert sizes["train"] + sizes["val"] + sizes["test"] == len(self.FORMULAS)
+
+    def test_requires_feature_names(self, tmp_path):
+        src = str(tmp_path / "src.lmdb")
+        _make_embed_format_lmdb(src, n=10)  # no feature_names metadata
+        with pytest.raises(ValueError, match="feature_names"):
+            split_lmdb_file(src, str(tmp_path / "out"), method="composition")
+
+    def test_hash_assignment_pinned(self):
+        """Pin the exact split assignment so it can't silently drift from the
+        converter path. Reference values generated from
+        qtaim_gen.source.utils.splits.assign_formula_to_split(formula, (0.6,0.2,0.2), 42).
+        """
+        from qtaim_embed.data.lmdb import _assign_formula_to_split
+        ratios = (0.6, 0.2, 0.2)
+        names = ("train", "val", "test")
+        expected = {
+            "H4C1": "train", "H6C2": "train", "H2C1O1": "train", "N2": "val",
+            "H2O2": "train", "Fe1O3": "train", "Ag1": "train",
+        }
+        for formula, exp in expected.items():
+            got = names[_assign_formula_to_split(formula, ratios, seed=42)]
+            assert got == exp, f"{formula}: got={got} expected={exp}"
+
+        # If qtaim_gen is importable (combined env), cross-check directly.
+        try:
+            from qtaim_gen.source.utils.splits import assign_formula_to_split
+        except Exception:
+            return
+        for formula in expected:
+            assert names[_assign_formula_to_split(formula, ratios, 42)] == \
+                assign_formula_to_split(formula, ratios, 42)
+
+    def test_invalid_method_raises(self, tmp_path):
+        src = str(tmp_path / "src.lmdb")
+        _make_embed_format_lmdb(src, n=5)
+        with pytest.raises(ValueError, match="method must be"):
+            split_lmdb_file(src, str(tmp_path / "out"), method="bogus")

--- a/tests/test_split_lmdb.py
+++ b/tests/test_split_lmdb.py
@@ -393,6 +393,13 @@ class TestCompositionSplit:
         for sig, splits in sig_to_splits.items():
             assert len(splits) == 1, f"formula {sig} leaked across splits {splits}"
 
+    def _split_sig_multisets(self, result):
+        """Return {split_name: sorted([formula_sig, ...])} for membership compare."""
+        out = {"train": [], "val": [], "test": []}
+        for (split_name, _key), sig in self._split_membership(result).items():
+            out[split_name].append(sig)
+        return {s: sorted(v) for s, v in out.items()}
+
     def test_composition_deterministic(self, tmp_path):
         src = str(tmp_path / "src.lmdb")
         _make_composition_lmdb(src, self.FORMULAS, self.ELEMS)
@@ -400,7 +407,8 @@ class TestCompositionSplit:
                              seed=7, method="composition")
         r2 = split_lmdb_file(src, str(tmp_path / "o2"), val_prop=0.2, test_prop=0.2,
                              seed=7, method="composition")
-        assert r1["sizes"] == r2["sizes"]
+        # per-molecule membership (by formula), not just sizes
+        assert self._split_sig_multisets(r1) == self._split_sig_multisets(r2)
 
     def test_total_preserved(self, tmp_path):
         src = str(tmp_path / "src.lmdb")
@@ -432,14 +440,42 @@ class TestCompositionSplit:
             got = names[_assign_formula_to_split(formula, ratios, seed=42)]
             assert got == exp, f"{formula}: got={got} expected={exp}"
 
-        # If qtaim_gen is importable (combined env), cross-check directly.
-        try:
-            from qtaim_gen.source.utils.splits import assign_formula_to_split
-        except Exception:
-            return
-        for formula in expected:
+    def test_hash_parity_with_qtaim_gen(self):
+        """Cross-check the local hash against qtaim_gen's directly. Skips
+        visibly when qtaim_gen is not importable (it isn't, inside the
+        qtaim_embed-only env), so this never silently passes."""
+        qg_splits = pytest.importorskip("qtaim_gen.source.utils.splits")
+        from qtaim_embed.data.lmdb import _assign_formula_to_split
+        ratios = (0.6, 0.2, 0.2)
+        names = ("train", "val", "test")
+        for formula in ["H4C1", "H6C2", "H2C1O1", "N2", "H2O2", "Fe1O3", "Ag1"]:
             assert names[_assign_formula_to_split(formula, ratios, 42)] == \
-                assign_formula_to_split(formula, ratios, 42)
+                qg_splits.assign_formula_to_split(formula, ratios, 42)
+
+    def test_empty_formula_routes_to_train(self, tmp_path):
+        """Graphs with no element columns set (formula derives to '') must all
+        go to train, matching the converter's missing-formula convention."""
+        src = str(tmp_path / "src.lmdb")
+        # "X" is absent from ELEMS, so its one-hot rows are all zeros ->
+        # element-column sums are 0 -> formula derives to "" for every molecule
+        _make_composition_lmdb(src, [{"X": 2}] * 20, self.ELEMS)
+        result = split_lmdb_file(src, str(tmp_path / "out"), val_prop=0.2, test_prop=0.2,
+                                 seed=7, method="composition")
+        assert result["sizes"] == {"train": 20, "val": 0, "test": 0}
+
+    def test_rejects_scaled_source(self, tmp_path):
+        """Composition split must refuse a scaled LMDB (element one-hots would
+        no longer be 0/1, silently corrupting formulas)."""
+        src = str(tmp_path / "src.lmdb")
+        _make_composition_lmdb(src, self.FORMULAS, self.ELEMS)
+        db = lmdb.open(src, map_size=10 ** 8, subdir=False, meminit=False, map_async=True)
+        txn = db.begin(write=True)
+        txn.put(b"scaled", pickle.dumps(True, protocol=-1))
+        txn.commit()
+        db.sync()
+        db.close()
+        with pytest.raises(ValueError, match="scaled"):
+            split_lmdb_file(src, str(tmp_path / "out"), method="composition")
 
     def test_invalid_method_raises(self, tmp_path):
         src = str(tmp_path / "src.lmdb")


### PR DESCRIPTION
This pull request adds support for composition-based splitting of LMDB datasets, ensuring that all molecules with the same chemical formula are assigned to the same split (train/val/test). This prevents data leakage between near-identical structures (such as trajectory steps of the same molecule). The changes also introduce robust metadata propagation to split files, improve error handling, and add comprehensive tests for the new functionality.

**New composition-based splitting:**

* Added a `method` parameter to `split_lmdb_file` and the CLI, allowing users to choose between "random" and "composition" splitting. In "composition" mode, molecules are grouped by derived chemical formula, and all molecules with the same formula are assigned to the same split using a deterministic hash function. [[1]](diffhunk://#diff-10ebcc3a9c1784af0ba73ee3b33e6240957232e121d3ec182f33ce9a68267309R531-R552) [[2]](diffhunk://#diff-e92691fb9e5f2c69e234de98d1dc580eb891db9a01b9a2496381c01e460f3b71R30-R38) [[3]](diffhunk://#diff-e92691fb9e5f2c69e234de98d1dc580eb891db9a01b9a2496381c01e460f3b71R48)
* Implemented helper functions (`_assign_formula_to_split`, `_element_columns_from_feature_names`, `_formula_from_graph`) to extract chemical formulas from graph data and assign them to splits in a way compatible with external tools.

**Metadata handling improvements:**

* Defined `_LMDB_METADATA_KEYS` and `_COPY_META` to ensure all relevant dataset metadata is copied verbatim into each split LMDB, so downstream tools and loaders have consistent access to metadata. [[1]](diffhunk://#diff-10ebcc3a9c1784af0ba73ee3b33e6240957232e121d3ec182f33ce9a68267309R399-R411) [[2]](diffhunk://#diff-d4f086fc3a66a8426d78de887e30833d8387cd3f3f70a47f4ef2d0a0d2a23b12R12)
* Updated `write_lmdb_split` to propagate metadata keys from the source LMDB to all split files.

**Testing enhancements:**

* Added extensive tests for composition-based splitting, including checks for deterministic split assignment, correct handling of missing/invalid metadata, and prevention of data leakage between splits.
* Added a test to verify that metadata is correctly propagated to each split.
* Updated existing tests to use the new metadata key set for filtering.

**Error handling and validation:**

* Added validation to reject composition-based splits if the source LMDB is scaled (to prevent formula corruption) or lacks necessary metadata.
* Ensured that invalid split methods raise a clear error. [[1]](diffhunk://#diff-10ebcc3a9c1784af0ba73ee3b33e6240957232e121d3ec182f33ce9a68267309R531-R552) [[2]](diffhunk://#diff-d4f086fc3a66a8426d78de887e30833d8387cd3f3f70a47f4ef2d0a0d2a23b12R303-R484)

**Dependency and import updates:**

* Added `hashlib` import for deterministic hashing in formula-based splitting.

These changes make the dataset splitting process more robust and flexible, especially for use cases where preventing data leakage across splits is critical.