### PR TITLE
Feature/iterative link node predictor

### DIFF
--- a/qtaim_embed/data/lmdb.py
+++ b/qtaim_embed/data/lmdb.py
@@ -566,15 +566,15 @@ def split_lmdb_file(
     if method not in ("random", "composition"):
         raise ValueError(f"method must be 'random' or 'composition', got {method!r}")
 
-    # readahead=False env for the random-access write pass; a separate
-    # readahead=True env for the sequential scan/derive passes, where OS
-    # prefetch is a large win on networked filesystems (Lustre).
-    src_env = open_lmdb_readonly(src_path)
-    scan_env = open_lmdb_readonly(src_path, readahead=True)
-    approx_total = scan_env.stat()["entries"]
+    # One readahead=True env. Every pass reads sequentially: the derive scan
+    # uses a cursor, and the write pass sorts each split's keys into storage
+    # order (below) so its reads sweep the file forward too. Sequential reads
+    # with OS prefetch are the difference between minutes and hours on Lustre.
+    src_env = open_lmdb_readonly(src_path, readahead=True)
+    approx_total = src_env.stat()["entries"]
 
     if method == "random":
-        with scan_env.begin() as txn:
+        with src_env.begin() as txn:
             all_keys = [
                 k
                 for k, _ in tqdm(txn.cursor(), desc="scanning source", total=approx_total)
@@ -592,7 +592,7 @@ def split_lmdb_file(
             "test": all_keys[n_train + n_val :],
         }
     else:  # composition
-        with scan_env.begin() as txn:
+        with src_env.begin() as txn:
             fn_raw = txn.get(b"feature_names")
             scaled_raw = txn.get(b"scaled")
         # composition needs raw 0/1 one-hot element columns; scaled features
@@ -621,7 +621,7 @@ def split_lmdb_file(
         formula_cache = {}
         # single sequential pass collects keys and derives formulas together
         # (avoids a separate full key-scan over the source).
-        with scan_env.begin() as txn:
+        with src_env.begin() as txn:
             for k, v in tqdm(txn.cursor(), desc="deriving formulas", total=approx_total):
                 if k in _LMDB_METADATA_KEYS:
                     continue
@@ -664,8 +664,6 @@ def split_lmdb_file(
             f"composition split: {n} molecules across {len(by_formula)} unique formulas"
         )
 
-    scan_env.close()
-
     n_train = len(splits["train"])
     n_val = len(splits["val"])
     n_test = len(splits["test"])
@@ -674,7 +672,10 @@ def split_lmdb_file(
     out_paths = {}
     for split_name, keys in splits.items():
         out_path = os.path.join(out_dir, split_name, lmdb_name)
-        write_lmdb_split(src_env, keys, out_path)
+        # sort into LMDB storage order so write-pass reads sweep the source
+        # sequentially (random per-key reads crawl on Lustre); membership is
+        # unchanged, only the 0..n re-indexing order.
+        write_lmdb_split(src_env, sorted(keys), out_path)
         out_paths[split_name] = out_path
 
     src_env.close()

--- a/qtaim_embed/data/lmdb.py
+++ b/qtaim_embed/data/lmdb.py
@@ -384,13 +384,18 @@ def combined_mean_std(mean_list, std_list, count_list):
 import random as _random
 
 
-def open_lmdb_readonly(path: str):
-    """Open an LMDB file for reading."""
+def open_lmdb_readonly(path: str, readahead: bool = False):
+    """Open an LMDB file for reading.
+
+    readahead defaults to False (best for the random-access dataloader). Pass
+    readahead=True for sequential full-file scans (e.g. the split passes),
+    where OS prefetch is a large win on networked filesystems like Lustre.
+    """
     return lmdb.open(
         path,
         readonly=True,
         lock=False,
-        readahead=False,
+        readahead=readahead,
         meminit=False,
         subdir=False,
     )
@@ -495,12 +500,16 @@ def _element_columns_from_feature_names(feature_names) -> list:
     ]
 
 
-def _formula_from_graph(graph, elem_cols) -> str:
+def _formula_from_graph(graph, elem_cols, formula_cache: dict = None) -> str:
     """Reconstruct a pymatgen formula string from atom element one-hot columns.
 
     Sums each chemical_symbol_* one-hot column across atoms to recover element
     counts, then formats via pymatgen Composition so the string matches
     build_formula_map_from_structure_lmdb's convention.
+
+    formula_cache (optional) memoizes the count-tuple -> formula mapping; a
+    dataset has far fewer distinct compositions than graphs, so this avoids
+    rebuilding pymatgen Composition for every record.
     """
     from pymatgen.core import Composition
 
@@ -518,7 +527,13 @@ def _formula_from_graph(graph, elem_cols) -> str:
             counts[sym] = c
     if not counts:
         return ""
-    return Composition(counts).formula.replace(" ", "")
+    cache_key = tuple(sorted(counts.items()))
+    if formula_cache is not None and cache_key in formula_cache:
+        return formula_cache[cache_key]
+    formula = Composition(counts).formula.replace(" ", "")
+    if formula_cache is not None:
+        formula_cache[cache_key] = formula
+    return formula
 
 
 def split_lmdb_file(
@@ -551,18 +566,21 @@ def split_lmdb_file(
     if method not in ("random", "composition"):
         raise ValueError(f"method must be 'random' or 'composition', got {method!r}")
 
+    # readahead=False env for the random-access write pass; a separate
+    # readahead=True env for the sequential scan/derive passes, where OS
+    # prefetch is a large win on networked filesystems (Lustre).
     src_env = open_lmdb_readonly(src_path)
-    stat = src_env.stat()
-    approx_total = stat["entries"]
-    with src_env.begin() as txn:
-        all_keys = [
-            k
-            for k, _ in tqdm(txn.cursor(), desc="scanning source", total=approx_total)
-            if k not in _LMDB_METADATA_KEYS
-        ]
-    n = len(all_keys)
+    scan_env = open_lmdb_readonly(src_path, readahead=True)
+    approx_total = scan_env.stat()["entries"]
 
     if method == "random":
+        with scan_env.begin() as txn:
+            all_keys = [
+                k
+                for k, _ in tqdm(txn.cursor(), desc="scanning source", total=approx_total)
+                if k not in _LMDB_METADATA_KEYS
+            ]
+        n = len(all_keys)
         rng = _random.Random(seed)
         rng.shuffle(all_keys)
         n_test = int(n * test_prop)
@@ -574,7 +592,7 @@ def split_lmdb_file(
             "test": all_keys[n_train + n_val :],
         }
     else:  # composition
-        with src_env.begin() as txn:
+        with scan_env.begin() as txn:
             fn_raw = txn.get(b"feature_names")
             scaled_raw = txn.get(b"scaled")
         # composition needs raw 0/1 one-hot element columns; scaled features
@@ -600,17 +618,22 @@ def split_lmdb_file(
         by_formula = {}
         n_failed = 0
         n_empty = 0
-        with src_env.begin() as txn:
-            for k in tqdm(all_keys, desc="deriving formulas"):
+        formula_cache = {}
+        # single sequential pass collects keys and derives formulas together
+        # (avoids a separate full key-scan over the source).
+        with scan_env.begin() as txn:
+            for k, v in tqdm(txn.cursor(), desc="deriving formulas", total=approx_total):
+                if k in _LMDB_METADATA_KEYS:
+                    continue
                 try:
-                    obj = pickle.loads(txn.get(k))
+                    obj = pickle.loads(v)
                     graph_bytes = obj["molecule_graph"] if isinstance(obj, dict) else obj
                     graph = (
                         load_graph_from_serialized(graph_bytes)
                         if isinstance(graph_bytes, (bytes, bytearray))
                         else graph_bytes
                     )
-                    formula = _formula_from_graph(graph, elem_cols)
+                    formula = _formula_from_graph(graph, elem_cols, formula_cache)
                 except Exception as e:
                     # a single bad record must not abort the whole split; route to train
                     logger.warning(
@@ -631,6 +654,7 @@ def split_lmdb_file(
                 splits["train"].extend(group)
             else:
                 splits[split_names[_assign_formula_to_split(formula, ratios, seed)]].extend(group)
+        n = sum(len(g) for g in splits.values())
         if n_failed or n_empty:
             logger.info(
                 f"composition split: routed {n_failed} failed + {n_empty} empty-formula "
@@ -639,6 +663,8 @@ def split_lmdb_file(
         logger.info(
             f"composition split: {n} molecules across {len(by_formula)} unique formulas"
         )
+
+    scan_env.close()
 
     n_train = len(splits["train"])
     n_val = len(splits["val"])

--- a/tests/test_split_lmdb.py
+++ b/tests/test_split_lmdb.py
@@ -482,3 +482,15 @@ class TestCompositionSplit:
         _make_embed_format_lmdb(src, n=5)
         with pytest.raises(ValueError, match="method must be"):
             split_lmdb_file(src, str(tmp_path / "out"), method="bogus")
+
+    def test_formula_cache_matches_uncached(self):
+        """Memoized formula derivation must equal the uncached result."""
+        from qtaim_embed.data.lmdb import _formula_from_graph
+        elem_cols = [(2, "C"), (3, "H"), (4, "O"), (5, "N")]
+        g = _make_composition_graph({"C": 2, "H": 6}, self.ELEMS)
+        cache = {}
+        uncached = _formula_from_graph(g, elem_cols)
+        first = _formula_from_graph(g, elem_cols, cache)
+        second = _formula_from_graph(g, elem_cols, cache)  # cache hit
+        assert uncached == first == second
+        assert len(cache) == 1

--- a/tests/test_split_lmdb.py
+++ b/tests/test_split_lmdb.py
@@ -195,14 +195,21 @@ class TestSplitLmdbFile:
         r1 = split_lmdb_file(src, str(tmp_path / "out1"), seed=1)
         r2 = split_lmdb_file(src, str(tmp_path / "out2"), seed=2)
 
-        def first_feat(lmdb_path):
+        def train_fingerprints(lmdb_path):
+            # set of per-graph fingerprints in train (write order is now
+            # storage-sorted, so compare membership, not a single entry)
             env = open_lmdb_readonly(lmdb_path)
+            fps = set()
             with env.begin() as txn:
-                raw = txn.get(b"0")
+                for k, v in txn.cursor():
+                    if k in _LMDB_METADATA_KEYS:
+                        continue
+                    g = load_graph_from_serialized(pickle.loads(v)["molecule_graph"])
+                    fps.add(round(float(g["atom"].feat.sum().item()), 6))
             env.close()
-            return load_graph_from_serialized(pickle.loads(raw)["molecule_graph"])["atom"].feat
+            return fps
 
-        assert not torch.allclose(first_feat(r1["train"]), first_feat(r2["train"]))
+        assert train_fingerprints(r1["train"]) != train_fingerprints(r2["train"])
 
     def test_readable_by_lmdb_molecule_dataset(self, tmp_path):
         src = str(tmp_path / "src.lmdb")


### PR DESCRIPTION
This pull request improves the performance and reliability of LMDB dataset splitting, especially for large datasets on networked filesystems. The main changes include optimizing sequential reads, adding formula memoization to reduce redundant computation, and improving test coverage and robustness.

**Performance and Data Handling Improvements:**

* The `open_lmdb_readonly` function now accepts a `readahead` parameter, defaulting to `False`, and is used with `readahead=True` in `split_lmdb_file` for sequential scans. This greatly speeds up operations on networked filesystems like Lustre. [[1]](diffhunk://#diff-10ebcc3a9c1784af0ba73ee3b33e6240957232e121d3ec182f33ce9a68267309L387-R398) [[2]](diffhunk://#diff-10ebcc3a9c1784af0ba73ee3b33e6240957232e121d3ec182f33ce9a68267309L554-L565)
* When splitting by composition, the code now performs a single sequential pass to derive formulas and collect keys, using a formula cache to avoid redundant computation of formulas for the same composition. [[1]](diffhunk://#diff-10ebcc3a9c1784af0ba73ee3b33e6240957232e121d3ec182f33ce9a68267309L498-R512) [[2]](diffhunk://#diff-10ebcc3a9c1784af0ba73ee3b33e6240957232e121d3ec182f33ce9a68267309L521-R536) [[3]](diffhunk://#diff-10ebcc3a9c1784af0ba73ee3b33e6240957232e121d3ec182f33ce9a68267309R621-R636)
* Output LMDB splits are now written in storage-sorted key order to ensure sequential reads during the write phase, further improving performance on certain filesystems.

**Testing Improvements:**

* The test for different seeds now compares set membership of fingerprints rather than relying on write order, making the test more robust to changes in output ordering.
* Added a new test to ensure that the formula caching logic produces results identical to the uncached version and that the cache is used as expected.