### PR TITLE
feat: store atom.pos/atom.z on graphs, fix scaler and zero-bond featurizer bugs

### DIFF
--- a/qtaim_embed/data/featurizer.py
+++ b/qtaim_embed/data/featurizer.py
@@ -117,10 +117,6 @@ class BondAsNodeGraphFeaturizerGeneral(BaseFeaturizer):
         features = mol.bond_features
         xyz_coordinates = mol.coords
 
-        # count number of keys in features
-        num_feats = len(self.selected_keys)
-        num_feats += 7
-
         bool_boo = False
         for key in self.selected_keys:
             if "boo_" in key:
@@ -141,13 +137,21 @@ class BondAsNodeGraphFeaturizerGeneral(BaseFeaturizer):
                 rbf_key_name = key
                 break  # only one RBF key supported
 
-        # Fix num_feats for zero-bond fallback: BOO and RBF keys expand
-        # into multiple features, but count as 1 key each above.
-        # NOTE: when adding new featurizer params that expand keys, update here.
+        # Row width for the zero-bond fallback. Must mirror the per-bond
+        # construction below exactly, or zero-bond molecules get a different
+        # feat width than the rest of the dataset and the scaler dies.
+        num_feats = len([
+            k for k in self.selected_keys
+            if k != "bond_length" and "boo_" not in k and "rbf_" not in k
+        ])
+        if self.allowed_ring_size != []:
+            num_feats += 2 + len(self.allowed_ring_size)
+        if "bond_length" in self.selected_keys:
+            num_feats += 1
         if bool_boo:
-            num_feats += (l_order + 1) ** 2 - 1
+            num_feats += (l_order + 1) ** 2
         if bool_rbf:
-            num_feats += rbf_n_basis - 1
+            num_feats += rbf_n_basis
 
         if num_bonds == 0:
             ft = [0.0 for _ in range(num_feats)]

--- a/qtaim_embed/data/grapher.py
+++ b/qtaim_embed/data/grapher.py
@@ -108,6 +108,10 @@ class HeteroCompleteGraphFromMolWrapper:
 
         data = build_hetero_graph_skeleton(num_atoms, bonds, self_loop=self.self_loop)
         data.mol_name = mol.id
+        data["atom"].pos = torch.tensor(mol.coords, dtype=torch.float32)
+        data["atom"].z = torch.tensor(
+            mol.pymatgen_mol.atomic_numbers, dtype=torch.long
+        )
 
         return data
 

--- a/qtaim_embed/data/processing.py
+++ b/qtaim_embed/data/processing.py
@@ -281,6 +281,10 @@ class HeteroGraphStandardScalerIterative:
             graph_key = "labels"
 
         node_types = list(_get_ndata(g, graph_key).keys())
+        # graphs with no entries for this track (e.g. no labels when
+        # keys_target is empty) have nothing to update
+        if not node_types:
+            return
         # obtain feats from ALL graphs
 
         for g in graphs:

--- a/tests/test_featurizers.py
+++ b/tests/test_featurizers.py
@@ -546,3 +546,38 @@ class TestRBFFeaturizerIntegration:
             f"Expected shape (1, {expected_width}), got {bond_feat_tensor.shape}"
         )
         assert not torch.any(torch.isnan(bond_feat_tensor))
+
+
+class TestZeroBondFallbackWidth:
+    """Zero-bond molecules must get the same bond-feat width as bonded ones.
+
+    The fallback row width is computed independently of the per-bond path;
+    a mismatch (e.g. the old hardcoded ring-block size) poisons a dataset
+    with rows the scaler cannot broadcast against.
+    """
+
+    def _featurize(self, bonds):
+        from qtaim_embed.core.molwrapper import (
+            create_wrapper_mol_from_atoms_and_bonds,
+        )
+        from qtaim_embed.data.featurizer import BondAsNodeGraphFeaturizerGeneral
+
+        mol = create_wrapper_mol_from_atoms_and_bonds(
+            species=["O", "H"],
+            coords=[[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]],
+            bonds=bonds,
+            bond_features={b: {} for b in bonds},
+        )
+        featurizer = BondAsNodeGraphFeaturizerGeneral(
+            selected_keys=["rbf_gaussian_50", "boo_1"],
+            allowed_ring_size=[3, 4, 5, 6, 7, 8],
+        )
+        feat_dict, names = featurizer(mol)
+        return feat_dict["feat"], names
+
+    def test_zero_bond_width_matches_bonded(self):
+        feats_bonded, names = self._featurize([(0, 1)])
+        feats_empty, names_empty = self._featurize([])
+        assert feats_bonded.shape[1] == len(names)
+        assert feats_empty.shape[1] == feats_bonded.shape[1]
+        assert names_empty == names

--- a/tests/test_grapher.py
+++ b/tests/test_grapher.py
@@ -1,6 +1,12 @@
+import numpy as np
 import pandas as pd
+import torch
+from torch_geometric.data import Batch
+
 from qtaim_embed.utils.grapher import get_grapher
 from qtaim_embed.data.molwrapper import mol_wrappers_from_df
+from qtaim_embed.data.lmdb import serialize_graph, load_graph_from_serialized
+from qtaim_embed.data.processing import HeteroGraphStandardScalerIterative
 from qtaim_embed.utils.tests import get_data
 
 
@@ -44,6 +50,61 @@ class TestGrapher:
             num_bonds_mol_wrapper = list_bond_num[ind]
             num_bonds = graph_list[ind]["bond"].num_nodes
             assert num_bonds_mol_wrapper == num_bonds
+
+    def test_pos_z(self):
+        mol_wrappers, element_set = mol_wrappers_from_df(
+            self.df_test,
+            bond_key="bonds",
+            map_key="extra_feat_bond_indices_qtaim",
+            atom_keys=["extra_feat_atom_esp_total"],
+            bond_keys=["extra_feat_bond_esp_total"],
+        )
+        grapher = get_grapher(
+            element_set,
+            atom_keys=["extra_feat_atom_esp_total"],
+            bond_keys=["extra_feat_bond_esp_total"],
+            global_keys=[],
+            allowed_ring_size=[3, 4, 5, 6, 7],
+            allowed_charges=None,
+            self_loop=True,
+        )
+
+        graphs = []
+        for mol in mol_wrappers:
+            graph = grapher.build_graph(mol)
+            pos = graph["atom"].pos
+            z = graph["atom"].z
+            assert pos.shape == (mol.num_atoms, 3)
+            assert pos.dtype == torch.float32
+            assert np.allclose(pos.numpy(), mol.coords, atol=1e-6)
+            assert z.shape == (mol.num_atoms,)
+            assert z.dtype == torch.long
+            assert z.tolist() == list(mol.pymatgen_mol.atomic_numbers)
+            graphs.append(grapher.featurize(graph, mol))
+
+        # serialization roundtrip preserves pos/z
+        loaded = load_graph_from_serialized(serialize_graph(graphs[0]))
+        assert torch.equal(loaded["atom"].pos, graphs[0]["atom"].pos)
+        assert torch.equal(loaded["atom"].z, graphs[0]["atom"].z)
+        assert loaded.mol_name == graphs[0].mol_name
+
+        # batching concatenates pos/z along the atom dimension
+        batched = Batch.from_data_list(graphs[:2])
+        n_total = graphs[0]["atom"].num_nodes + graphs[1]["atom"].num_nodes
+        assert batched["atom"].pos.shape == (n_total, 3)
+        assert batched["atom"].z.shape == (n_total,)
+
+        # feature scaler must leave pos/z untouched
+        pos_before = graphs[0]["atom"].pos.clone()
+        z_before = graphs[0]["atom"].z.clone()
+        scaler = HeteroGraphStandardScalerIterative(
+            features_tf=True, mean={}, std={}
+        )
+        scaler.update(graphs)
+        scaler.finalize()
+        scaled = scaler(graphs)
+        assert torch.equal(scaled[0]["atom"].pos, pos_before)
+        assert torch.equal(scaled[0]["atom"].z, z_before)
 
 
 # tester = TestGrapher()


### PR DESCRIPTION
## Summary

- `build_graph` now attaches `atom.pos` (float32 cartesian coords) and `atom.z` (int64 atomic numbers) to every graph. The attributes survive `torch.save` serialization and PyG batching, and are ignored by the feat/labels scalers and existing models - groundwork for SchNet/DimeNet/MACE-style layers without another rebuild.
- Fix: `HeteroGraphStandardScalerIterative.update()` crashed with `IndexError` on graphs with no entries for its track (e.g. no `labels` anywhere when `keys_target` is empty). Now a no-op. Before this, any no-target converter run built zero graphs while exiting 0.
- Fix: the bond featurizer's zero-bond fallback row width was computed from a hardcoded `+7` ring block (2 cols + 5 ring sizes). Any config with a different `allowed_ring_size` produced zero-bond rows narrower than bonded rows (61 vs 62 with 6 ring sizes + `rbf_gaussian_50` + `boo_1`), which poisons a dataset for the scaler. Width is now derived from the same blocks as the per-bond path. Found in production: two zero-bond radical-pair diatomics in rmechdb crashed the OMol scaler apply.

## Test plan

- New `tests/test_grapher.py::TestGrapher::test_pos_z` - values match `mol.coords`/atomic numbers, serialization roundtrip, batch concatenation, scaler leaves pos/z untouched.
- New `tests/test_featurizers.py::TestZeroBondFallbackWidth` - zero-bond width equals bonded width and `feature_names` length (fails on the old code).
- Full local rebuild of 7 OMol verticals (201k graphs) + scaler fit/apply completed clean against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)